### PR TITLE
:art: adjust padding for files

### DIFF
--- a/src/components/FileTree.tsx
+++ b/src/components/FileTree.tsx
@@ -6,11 +6,13 @@ import styled, { css } from "styled-components";
 
 export interface FileProps {
   children?: React.ReactNode;
+  depth?: number;
   file: FSNode;
   isSelected?: boolean;
 }
 
 export interface FileTreeProps {
+  depth?: number;
   fileTree: FSNode;
   selectedFile?: FSNode;
 }
@@ -24,13 +26,14 @@ const IconMap: Record<FileType, keyof typeof Icons> = {
   [FileType.Video]: "FiVideo",
 };
 
-const FileDetails = styled.div<{ isSelected?: boolean }>`
+const FileDetails = styled.div<{ depth: number; isSelected?: boolean }>`
   align-items: center;
   cursor: pointer;
   display: flex;
   gap: 0.5rem;
   list-style: none;
   padding: 0.25rem 1rem;
+  padding-left: ${(props) => props.depth * 2}rem;
 
   ${(props) =>
     props.isSelected &&
@@ -45,12 +48,11 @@ const FileDetails = styled.div<{ isSelected?: boolean }>`
   }
 `;
 
-const FileWrapper = styled.li`
+const FileWrapper = styled.li<{ depth?: number }>`
   align-items: center;
   cursor: pointer;
   gap: 0.5rem;
   list-style: none;
-  padding-left: 2rem;
 `;
 
 export function File(props: FileProps) {
@@ -62,7 +64,7 @@ export function File(props: FileProps) {
     <>
       <Link href={props.file.path} scroll={false}>
         <FileWrapper>
-          <FileDetails isSelected={props.isSelected}>
+          <FileDetails depth={props.depth} isSelected={props.isSelected}>
             <Icon />
             <Text maxLineCount={1}>{props.file.name}</Text>
           </FileDetails>
@@ -77,6 +79,7 @@ export function File(props: FileProps) {
 export function FileTree(props: FileTreeProps) {
   return (
     <File
+      depth={props.depth}
       file={props.fileTree}
       isSelected={props.selectedFile?.path === props.fileTree.path}
     >
@@ -84,6 +87,7 @@ export function FileTree(props: FileTreeProps) {
         <ul style={{ margin: 0, padding: 0 }}>
           {props.fileTree.children.map((child) => (
             <FileTree
+              depth={props.depth ? props.depth + 1 : 1}
               key={child.path}
               fileTree={child}
               selectedFile={props.selectedFile}

--- a/src/components/MediaPlayer.tsx
+++ b/src/components/MediaPlayer.tsx
@@ -46,6 +46,7 @@ export function MediaPlayer(props: MediaPlayerProps) {
 
   React.useEffect(() => {
     mediaPlayerRef.current?.load();
+    mediaPlayerRef.current?.play();
 
     return () => {
       mediaPlayerRef.current?.pause();

--- a/src/pages/[[...path]].tsx
+++ b/src/pages/[[...path]].tsx
@@ -15,7 +15,7 @@ export default function Home(
 
   return (
     <BasicLayout title={props.fileTree.path}>
-      <Container $p={3}>
+      <Container $p={2}>
         {props.fileTree.children?.map((file) => (
           <FileTree
             key={file.path}


### PR DESCRIPTION
Fixes padding of files:

- top-level files don't have unnecessary left padding
- nested files are selectable even to the left of the icon